### PR TITLE
Fix python 2 division issue in the Simpson integraton component

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ init:
 
 install:
   - set CONDA=Miniconda
+  - if "%PYTHON%" == "3.6" (set CONDA=Miniconda3)
   - if "%PLATFORM%" == "x64" (set CONDA=%CONDA%-x64)
   - echo %CONDA%
   - set PATH=C:\%CONDA%;C:\%CONDA%\Scripts;%PATH%

--- a/openconcept/utilities/math/simpson_integration.py
+++ b/openconcept/utilities/math/simpson_integration.py
@@ -233,6 +233,8 @@ class IntegrateQuantity(ExplicitComponent):
         ddQddt = sp.csr_matrix((wrt_dt[2][0],(wrt_dt[0][0],wrt_dt[1][0])))
 
         J['delta_quantity','rate'] = np.asarray(ddQdq.sum(axis=0)).flatten()
+        print('Partial to check:')
+        print(np.asarray(ddQdq.sum(axis=0)).flatten())
         #partial derivative wrt the time interval
         dQddt = ddQddt.sum()
 

--- a/openconcept/utilities/math/simpson_integration.py
+++ b/openconcept/utilities/math/simpson_integration.py
@@ -1,7 +1,7 @@
+from __future__ import division
 import numpy as np
 import scipy.sparse as sp
 from openmdao.api import ExplicitComponent
-from __future__ import division
 
 def simpson_integral(dts, q, n_segments=1, n_simpson_intervals_per_segment=2):
     """

--- a/openconcept/utilities/math/simpson_integration.py
+++ b/openconcept/utilities/math/simpson_integration.py
@@ -83,8 +83,6 @@ def simpson_partials(dts, q, n_segments=1, n_simpson_intervals_per_segment=2,):
     # create a placeholder for the column indices
     colidx_wrt_q = np.zeros(n_int_tot * 3)
     partials_wrt_q = np.tile([1 / 3, 4 / 3, 1 / 3], n_int_tot)
-    print('line86')
-    print(partials_wrt_q)
     rowidxs_wrt_dt = []
     colidxs_wrt_dt = []
     partials_wrt_dt = []
@@ -231,11 +229,7 @@ class IntegrateQuantity(ExplicitComponent):
         nn = (n_int*2 + 1)
         dts = (inputs['upper_limit'] - inputs['lower_limit']) / (nn - 1)
         wrt_q, wrt_dt = simpson_partials(dts,inputs['rate'],n_segments=1,n_simpson_intervals_per_segment=n_int)
-        print('wrt_q')
-        print(wrt_q)
         ddQdq = sp.csr_matrix((wrt_q[2],(wrt_q[0],wrt_q[1])))
-        print('ddQdq')
-        print(ddQdq)
         ddQddt = sp.csr_matrix((wrt_dt[2][0],(wrt_dt[0][0],wrt_dt[1][0])))
 
         J['delta_quantity','rate'] = np.asarray(ddQdq.sum(axis=0)).flatten()

--- a/openconcept/utilities/math/simpson_integration.py
+++ b/openconcept/utilities/math/simpson_integration.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.sparse as sp
 from openmdao.api import ExplicitComponent
-
+from __future__ import division
 
 def simpson_integral(dts, q, n_segments=1, n_simpson_intervals_per_segment=2):
     """

--- a/openconcept/utilities/math/simpson_integration.py
+++ b/openconcept/utilities/math/simpson_integration.py
@@ -83,6 +83,8 @@ def simpson_partials(dts, q, n_segments=1, n_simpson_intervals_per_segment=2,):
     # create a placeholder for the column indices
     colidx_wrt_q = np.zeros(n_int_tot * 3)
     partials_wrt_q = np.tile([1 / 3, 4 / 3, 1 / 3], n_int_tot)
+    print('line86')
+    print(partials_wrt_q)
     rowidxs_wrt_dt = []
     colidxs_wrt_dt = []
     partials_wrt_dt = []
@@ -229,12 +231,14 @@ class IntegrateQuantity(ExplicitComponent):
         nn = (n_int*2 + 1)
         dts = (inputs['upper_limit'] - inputs['lower_limit']) / (nn - 1)
         wrt_q, wrt_dt = simpson_partials(dts,inputs['rate'],n_segments=1,n_simpson_intervals_per_segment=n_int)
+        print('wrt_q')
+        print(wrt_q)
         ddQdq = sp.csr_matrix((wrt_q[2],(wrt_q[0],wrt_q[1])))
+        print('ddQdq')
+        print(ddQdq)
         ddQddt = sp.csr_matrix((wrt_dt[2][0],(wrt_dt[0][0],wrt_dt[1][0])))
 
         J['delta_quantity','rate'] = np.asarray(ddQdq.sum(axis=0)).flatten()
-        print('Partial to check:')
-        print(np.asarray(ddQdq.sum(axis=0)).flatten())
         #partial derivative wrt the time interval
         dQddt = ddQddt.sum()
 

--- a/openconcept/utilities/math/tests/test_math.py
+++ b/openconcept/utilities/math/tests/test_math.py
@@ -1,5 +1,5 @@
 import unittest
-import numpy as np 
+import numpy as np
 from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
 from openmdao.api import IndepVarComp, Group, Problem
 from openconcept.utilities.math.simpson_integration import IntegrateQuantity
@@ -21,7 +21,7 @@ class SimpsonTestGroup(Group):
         self.connect('iv.function','integrate.rate')
         #output is 'delta quantity'
 
-class VectorAtmosTestCase(unittest.TestCase):
+class SimpsonTestCase(unittest.TestCase):
     def test_uniform_single(self):
         prob = Problem(SimpsonTestGroup(n_simp_intervals=1))
         prob.setup(check=True)
@@ -43,8 +43,8 @@ class VectorAtmosTestCase(unittest.TestCase):
         prob.setup(check=False)
         prob['iv.end_pt'] = 2
         prob.run_model()
-        assert_rel_error(self,prob['delta_quantity'],2.,tolerance=1e-15)    
-        
+        assert_rel_error(self,prob['delta_quantity'],2.,tolerance=1e-15)
+
     def test_function_level(self):
         prob = Problem(SimpsonTestGroup(n_simp_intervals=5))
         prob.setup(check=False)


### PR DESCRIPTION
Porting Windows testing to appveyor revealed a problem with Python2 (failed 4 tests). Debugged and fixed the issue and now Appveyor is passing too.